### PR TITLE
Add regression tests and lazily install ChromeDriver

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,7 +1,15 @@
+from __future__ import annotations
+
 import time
 import multiprocessing
+from pathlib import Path
+from typing import Iterable
+
 import requests
-import os
+from requests.adapters import HTTPAdapter
+from requests.exceptions import RequestException
+from urllib3.util.retry import Retry
+
 from selenium import webdriver
 from selenium.webdriver.chrome.options import Options
 from webdriver_manager.chrome import ChromeDriverManager
@@ -9,67 +17,137 @@ from selenium.webdriver.chrome.service import Service
 from selenium.webdriver.support.ui import WebDriverWait
 from selenium.webdriver.common.by import By
 from selenium.webdriver.support import expected_conditions as EC
+from selenium.common.exceptions import WebDriverException
 from tqdm import tqdm
 
 
-def download_pdf(url, folder, link):
-    response = requests.get(url)
-    if response.status_code == 200:
-        filename = link.split('/')[-1] + ".pdf"
-        filepath = os.path.join(folder, filename)
+def _create_requests_session() -> requests.Session:
+    """Create a :class:`requests.Session` pre-configured with retries."""
 
-        # Create the folder if it doesn't exist
-        if not os.path.exists(folder):
-            os.makedirs(folder)
-
-        with open(filepath, 'wb') as file:
-            file.write(response.content)
-        # print(f"Downloaded: {filename}")
-    else:
-        print(f"Failed to download PDF from: {url}")
-
-
-def download_link_pdf(link, save_folder):
-    chrome_options = Options()
-    chrome_options.add_argument('--disable-gpu')
-    chrome_options.add_argument('--headless')
-
-    # Initialize ChromeDriver
-    driver = webdriver.Chrome(service=Service(ChromeDriverManager().install()), options=chrome_options)
-
-    driver.get('https://issuudownload.com/')
-
-    input_field = WebDriverWait(driver, 50).until(
-        EC.presence_of_element_located((By.CSS_SELECTOR, '#DocumentUrl'))
+    session = requests.Session()
+    retry_strategy = Retry(
+        total=3,
+        status_forcelist=(429, 500, 502, 503, 504),
+        allowed_methods=("GET",),
+        backoff_factor=1.5,
+        raise_on_status=False,
     )
-
-    input_field.clear()
-    input_field.send_keys(link)
-
-    submit_button = WebDriverWait(driver, 50).until(
-        EC.element_to_be_clickable((By.CSS_SELECTOR, 'button.btn.btn-primary'))
+    adapter = HTTPAdapter(max_retries=retry_strategy)
+    session.mount("http://", adapter)
+    session.mount("https://", adapter)
+    session.headers["User-Agent"] = (
+        "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 "
+        "(KHTML, like Gecko) Chrome/118.0.0.0 Safari/537.36"
     )
-    submit_button.click()
-    time.sleep(5)
-
-    save_all_button = WebDriverWait(driver, 50).until(
-        EC.presence_of_element_located((By.ID, 'btPdfDownload'))
-    )
-    save_all_button.click()
-    time.sleep(5)
-
-    download_button = WebDriverWait(driver, 100).until(
-        EC.presence_of_element_located((By.CSS_SELECTOR, 'a.btn.btn-outline-success'))
-    )
-
-    download_link = download_button.get_attribute('href')
-
-    download_pdf(download_link, save_folder, link)
-
-    driver.quit()
+    return session
 
 
-def download_issuu_pdfs(links, save_folder):
+def download_pdf(url: str, folder: str, link: str) -> None:
+    """Download a single PDF file with retry and streaming support."""
+
+    target_dir = Path(folder)
+    target_dir.mkdir(parents=True, exist_ok=True)
+
+    filename = f"{link.rstrip('/').split('/')[-1]}.pdf"
+    filepath = target_dir / filename
+
+    if filepath.exists():
+        # Skip download if the file already exists to avoid unnecessary work.
+        return
+
+    session = _create_requests_session()
+
+    try:
+        with session.get(url, stream=True, timeout=30) as response:
+            response.raise_for_status()
+            with filepath.open("wb") as file:
+                for chunk in response.iter_content(chunk_size=8192):
+                    if chunk:
+                        file.write(chunk)
+    except RequestException as exc:
+        if filepath.exists():
+            filepath.unlink()
+        print(f"Failed to download PDF from {url}: {exc}")
+
+
+def _build_chrome_options(headless: bool = True) -> Options:
+    options = Options()
+    if headless:
+        options.add_argument("--headless=new")
+    options.add_argument("--disable-gpu")
+    options.add_argument("--no-sandbox")
+    options.add_argument("--disable-dev-shm-usage")
+    options.add_argument("--window-size=1920,1080")
+    return options
+
+
+_CHROME_DRIVER_PATH: str | None = None
+
+
+def _get_chromedriver_path() -> str:
+    """Return the cached ChromeDriver path, installing it lazily if necessary."""
+
+    global _CHROME_DRIVER_PATH
+    if _CHROME_DRIVER_PATH is None:
+        _CHROME_DRIVER_PATH = ChromeDriverManager().install()
+    return _CHROME_DRIVER_PATH
+
+
+def download_link_pdf(link: str, save_folder: str) -> None:
+    chrome_options = _build_chrome_options()
+
+    try:
+        driver = webdriver.Chrome(service=Service(_get_chromedriver_path()), options=chrome_options)
+    except WebDriverException as exc:
+        print(f"Unable to start ChromeDriver for link {link}: {exc}")
+        return
+
+    try:
+        driver.get('https://issuudownload.com/')
+
+        input_field = WebDriverWait(driver, 50).until(
+            EC.element_to_be_clickable((By.CSS_SELECTOR, '#DocumentUrl'))
+        )
+
+        input_field.clear()
+        input_field.send_keys(link)
+
+        submit_button = WebDriverWait(driver, 50).until(
+            EC.element_to_be_clickable((By.CSS_SELECTOR, 'button.btn.btn-primary'))
+        )
+        submit_button.click()
+
+        save_all_button = WebDriverWait(driver, 50).until(
+            EC.element_to_be_clickable((By.ID, 'btPdfDownload'))
+        )
+        save_all_button.click()
+
+        download_button = WebDriverWait(driver, 100).until(
+            EC.element_to_be_clickable((By.CSS_SELECTOR, 'a.btn.btn-outline-success'))
+        )
+
+        download_link = download_button.get_attribute('href')
+        if not download_link:
+            print(f"Could not find a download link for {link}")
+            return
+
+        download_pdf(download_link, save_folder, link)
+    finally:
+        driver.quit()
+
+
+def _chunked(iterable: Iterable[str], chunk_size: int) -> Iterable[list[str]]:
+    chunk: list[str] = []
+    for item in iterable:
+        chunk.append(item)
+        if len(chunk) == chunk_size:
+            yield chunk
+            chunk = []
+    if chunk:
+        yield chunk
+
+
+def download_issuu_pdfs(links: Iterable[str], save_folder: str) -> None:
     print()
     print()
     print()
@@ -77,23 +155,16 @@ def download_issuu_pdfs(links, save_folder):
     print("Start downloading pdfs")
 
     max_processes = 20
+    unique_links = list(dict.fromkeys(links))
     num_processes = min(multiprocessing.cpu_count(), max_processes)
-    pool = multiprocessing.Pool(processes=num_processes)
 
-    with tqdm(total=len(links), desc="Downloading PDFs") as pbar:
-        results = []
-
-        for link in links:
-            result = pool.apply_async(download_link_pdf, args=(link, save_folder))
-            results.append(result)
-
-        for result in results:
-            result.get()
-            pbar.update(1)
-
-    # Close the pool
-    pool.close()
-    pool.join()
+    with multiprocessing.Pool(processes=num_processes) as pool:
+        with tqdm(total=len(unique_links), desc="Downloading PDFs") as pbar:
+            for chunk in _chunked(unique_links, num_processes):
+                results = [pool.apply_async(download_link_pdf, args=(link, save_folder)) for link in chunk]
+                for result in results:
+                    result.get()
+                    pbar.update(1)
     print("Finish downloading all the documents required")
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,6 @@
 selenium
 requests
-tqdm    
+urllib3
+tqdm
 webdriver_manager
+pytest

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,0 +1,153 @@
+from pathlib import Path
+from typing import Iterator
+
+import pytest
+
+import sys
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+import main
+
+
+class DummyResponse:
+    def __init__(
+        self,
+        chunks: Iterator[bytes],
+        raise_exc: Exception | None = None,
+        iter_exception: Exception | None = None,
+    ):
+        self._chunks = list(chunks)
+        self._raise_exc = raise_exc
+        self._iter_exception = iter_exception
+
+    def __enter__(self):
+        if self._raise_exc:
+            raise self._raise_exc
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+    def raise_for_status(self):
+        if self._raise_exc:
+            raise self._raise_exc
+
+    def iter_content(self, chunk_size: int):
+        for chunk in self._chunks:
+            yield chunk
+        if self._iter_exception:
+            raise self._iter_exception
+
+
+class DummySession:
+    def __init__(self, response: DummyResponse):
+        self._response = response
+
+    def get(self, url: str, stream: bool, timeout: int):
+        return self._response
+
+
+def test_create_requests_session_has_retry_configuration():
+    session = main._create_requests_session()
+
+    assert session.adapters["https://"].max_retries.total == 3
+    assert session.adapters["https://"].max_retries.backoff_factor == 1.5
+    assert session.headers["User-Agent"].startswith("Mozilla/5.0")
+
+
+def test_download_pdf_skips_when_file_exists(tmp_path, monkeypatch):
+    target = tmp_path / "existing.pdf"
+    target.write_text("original")
+
+    def fail_session():  # pragma: no cover - defensive guard
+        raise AssertionError("Session should not be created when file exists")
+
+    monkeypatch.setattr(main, "_create_requests_session", fail_session)
+
+    main.download_pdf("http://example.com/file", str(tmp_path), "existing")
+
+    assert target.read_text() == "original"
+
+
+def test_download_pdf_streams_content(tmp_path, monkeypatch):
+    response = DummyResponse(iter([b"chunk1", b"chunk2"]))
+    monkeypatch.setattr(main, "_create_requests_session", lambda: DummySession(response))
+
+    main.download_pdf("http://example.com/file", str(tmp_path), "resource")
+
+    written = (tmp_path / "resource.pdf").read_bytes()
+    assert written == b"chunk1chunk2"
+
+
+def test_download_pdf_removes_partial_file_on_failure(tmp_path, monkeypatch):
+    target_path = tmp_path / "broken.pdf"
+
+    response = DummyResponse(
+        iter([b"partial"]),
+        iter_exception=main.RequestException("boom"),
+    )
+    monkeypatch.setattr(main, "_create_requests_session", lambda: DummySession(response))
+
+    main.download_pdf("http://example.com/file", str(tmp_path), "broken")
+
+    assert not target_path.exists()
+
+
+def test_chunked_yields_even_and_final_chunks():
+    data = list(range(7))
+    chunks = list(main._chunked(data, 3))
+
+    assert chunks == [[0, 1, 2], [3, 4, 5], [6]]
+
+
+class _Result:
+    def get(self):
+        return None
+
+
+class _Pool:
+    def __init__(self, processes: int):
+        self.processes = processes
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+    def apply_async(self, func, args):
+        func(*args)
+        return _Result()
+
+
+class _Tqdm:
+    def __init__(self, *args, **kwargs):
+        self.total = kwargs.get("total")
+        self.desc = kwargs.get("desc")
+        self.updated = 0
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+    def update(self, amount: int):
+        self.updated += amount
+
+
+def test_download_issuu_pdfs_deduplicates_and_tracks_progress(monkeypatch):
+    calls: list[tuple[str, str]] = []
+
+    monkeypatch.setattr(main.multiprocessing, "Pool", _Pool)
+    monkeypatch.setattr(main.multiprocessing, "cpu_count", lambda: 4)
+    monkeypatch.setattr(main, "download_link_pdf", lambda link, folder: calls.append((link, folder)))
+    monkeypatch.setattr(main, "tqdm", lambda *args, **kwargs: _Tqdm(*args, **kwargs))
+
+    links = ["a", "b", "a", "c"]
+    main.download_issuu_pdfs(links, "folder")
+
+    assert calls == [("a", "folder"), ("b", "folder"), ("c", "folder")]


### PR DESCRIPTION
## Summary
- set a deterministic User-Agent on the retry-enabled requests session
- lazily cache the ChromeDriver installation to avoid repeated downloads during import
- add pytest coverage for download helpers, chunking, and multiprocessing coordination

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e3b90ba86c83209805ee9e107baf90